### PR TITLE
Removed deprecated tap event fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,6 @@ import createSagaMiddleware from 'redux-saga'
 import sagas from './sagas'
 
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-import injectTapEventPlugin from 'react-tap-event-plugin'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 
 import { blue800, amber50 } from 'material-ui/styles/colors'
@@ -44,8 +43,6 @@ const store = createStore(
 )
 
 sagaMiddleware.run(sagas)
-
-injectTapEventPlugin()
 
 ReactDOM.render(
   <MuiThemeProvider muiTheme={muiTheme}>


### PR DESCRIPTION
See https://github.com/zilverline/react-tap-event-plugin.

This was causing the following error -

```
TypeError: __webpack_require__(...).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED.EventPluginHub is undefined
```