### PR TITLE
Fix type attribute of password inputs

### DIFF
--- a/app/src/components/authComponents.tsx
+++ b/app/src/components/authComponents.tsx
@@ -27,6 +27,7 @@ export const Password: React.FunctionComponent<{
   return (
     <TextField
       fullWidth
+      type="password"
       variant="outlined"
       label={passwordIsValid ? label : 'Minimum 8 characters'}
       error={!passwordIsValid}


### PR DESCRIPTION
The example is using HTML inputs with `type="text"` for its password fields. Instead it should be using `type="password"` to hide the input and have built-in autocompletes (notice lock symbol next to the input) working properly.

|                                                  Before                                                   |                                                   After                                                   |
| :-------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------: |
| ![](https://user-images.githubusercontent.com/7649376/143775162-e805294e-6afd-45d6-85a5-5bb3c5c376b9.png) | ![](https://user-images.githubusercontent.com/7649376/143775163-019fd784-577a-4a02-9dec-07069fb336b3.png) |
